### PR TITLE
League-Entity + LeaguePersistenceService

### DIFF
--- a/backend/src/main/java/entities/League.java
+++ b/backend/src/main/java/entities/League.java
@@ -1,13 +1,17 @@
 package entities;
-import javax.persistence.Entity;
+import javax.persistence.*;
 
 @Entity
 public class League extends EntityGeneratedKey {
 
+	@Id
 	private int leagueId;
 
+	@Id
 	private String season;
 
+	@ManyToOne(fetch=FetchType.LAZY)
+	@JoinColumn(name="current_Matchday")
 	private Matchday currentMatchday;
 
 	public int getLeagueId() {

--- a/backend/src/main/java/entities/League.java
+++ b/backend/src/main/java/entities/League.java
@@ -3,6 +3,34 @@ import javax.persistence.Entity;
 
 @Entity
 public class League extends EntityGeneratedKey {
+
 	private int leagueId;
-	private String season;  //e.g. 2018
+
+	private String season;
+
+	private Matchday currentMatchday;
+
+	public int getLeagueId() {
+		return leagueId;
+	}
+
+	public void setLeagueId(int leagueId) {
+		this.leagueId = leagueId;
+	}
+
+	public String getSeason() {
+		return season;
+	}
+
+	public void setSeason(String season) {
+		this.season = season;
+	}
+
+	public Matchday getCurrentMatchday() {
+		return currentMatchday;
+	}
+
+	public void setCurrentMatchday(Matchday currentMatchday) {
+		this.currentMatchday = currentMatchday;
+	}
 }

--- a/backend/src/main/java/persistence/LeaguePersistenceService.java
+++ b/backend/src/main/java/persistence/LeaguePersistenceService.java
@@ -1,0 +1,22 @@
+package persistence;
+
+import entities.League;
+
+/**
+ *
+ */
+public class LeaguePersistenceService extends PersistenceService<League> {
+
+    private static LeaguePersistenceService instance;
+
+    /**
+     *
+     * @return
+     */
+    public static LeaguePersistenceService getInstance()
+    {
+        return instance = instance != null ? instance : new LeaguePersistenceService();
+    }
+
+}
+

--- a/backend/src/main/java/persistence/LeaguePersistenceService.java
+++ b/backend/src/main/java/persistence/LeaguePersistenceService.java
@@ -2,6 +2,10 @@ package persistence;
 
 import entities.League;
 
+import javax.persistence.NoResultException;
+import javax.persistence.Query;
+import java.util.List;
+
 /**
  *
  */
@@ -18,5 +22,16 @@ public class LeaguePersistenceService extends PersistenceService<League> {
         return instance = instance != null ? instance : new LeaguePersistenceService();
     }
 
+    public League getCurrentLeague() throws NoResultException{
+        return JPAOperations.doInJPA(this::entityManagerFactory, entityManager -> {
+            Query query = entityManager.createQuery("select l from league l order by l.season desc");
+            List<League> leagues = query.getResultList();
+            if (leagues.isEmpty()) {
+                throw new NoResultException();
+            } else {
+                return leagues.get(0);
+            }
+        });
+    }
 }
 


### PR DESCRIPTION
- League-Entität modifiziert, Id annotationen hinzugefügt, getter und setter generiert
- currentMatchday als attribut ergänzt
- LeaguePersistenceService erstellt (initial)

fix #105  - der Matchday muss dafür in der Liga hinterlegt werden